### PR TITLE
DoH servers are identified by URIs and not addresses.

### DIFF
--- a/draft-rescorla-doh-cdisco.md
+++ b/draft-rescorla-doh-cdisco.md
@@ -124,7 +124,7 @@ the network takes the following steps:
 
 3. If the query succeeds, then look up the CNAME record value in the list
    of preconfigured resolvers. If an exact match is found, then use the
-   resolver address for the matching preconfigured resolver.
+   DoH resolver URI for the matching preconfigured resolver.
    Otherwise fall back to the ordinary DoH resolver selection logic.
 
 3. If the query fails, then no associated resolver is present;


### PR DESCRIPTION
Moin!

I assume DoH resolvers are confgiured by URIs and not IP addresses, just changed this to let the text be more precise.

So long
-Ralf
